### PR TITLE
TEST_CREATE is a Boolean rather than a string.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,7 +90,7 @@ Standard Django settings
 
 -  TEST_CREATE
 
-   String. If it is set to ``False``, the test database won’t be
+   Boolean. If it is set to ``False``, the test database won’t be
    automatically created at the beginning of the tests and dropped at the end.
    This is useful not to be charged too much for creating new databases
    in every test when you run tests with Windows Azure SQL Database.


### PR DESCRIPTION
In my testing just now on SQL Server 2008R2, using `'TEST_CREATE': 'False',` did not work, while using `'TEST_CREATE': False,` did.
