### PR TITLE
cp949 encoding problem

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -105,7 +105,7 @@ for any given database-level settings dictionary:
 
 -  CREATE_DB
 
-   Boolean. If it is set to ``False``, the test database won’t be
+   Boolean. If it is set to ``False``, the test database won't be
    automatically created at the beginning of the tests and dropped at the end.
    This is useful not to be charged too much for creating new databases
    in every test when you run tests with Azure SQL Database.


### PR DESCRIPTION
Hello.
I have met error on "pip install django-pyodbc-azure".

occur exception at setup.py/Python3.4.2
open('README.rst').read()
cp949 encoding cannot decode ’(U+2019).
cp949 encoding is south korea default encoding.

I will be glad if you'll pull it.
Thank you.
