### PR TITLE
Django 1.8 compatibility

### DIFF
--- a/sql_server/pyodbc/client.py
+++ b/sql_server/pyodbc/client.py
@@ -1,6 +1,10 @@
 import re
 
-from django.db.backends import BaseDatabaseClient
+try:
+    from django.db.backends.base.client import BaseDatabaseClient
+except ImportError:
+    from django.db.backends import BaseDatabaseClient
+
 
 class DatabaseClient(BaseDatabaseClient):
     executable_name = 'sqlcmd'

--- a/sql_server/pyodbc/compiler.py
+++ b/sql_server/pyodbc/compiler.py
@@ -22,7 +22,7 @@ class SQLCompiler(compiler.SQLCompiler):
             values.append(value)
         return tuple(values)
 
-    def as_sql(self, with_limits=True, with_col_aliases=False):
+    def as_sql(self, with_limits=True, with_col_aliases=False, subquery=False):
         """
         Creates the SQL for this query. Returns the SQL string and list of
         parameters.
@@ -30,6 +30,7 @@ class SQLCompiler(compiler.SQLCompiler):
         If 'with_limits' is False, any limit/offset information is not included
         in the query.
         """
+        self.subquery = subquery
         if with_limits and self.query.low_mark == self.query.high_mark:
             return '', ()
 

--- a/sql_server/pyodbc/compiler.py
+++ b/sql_server/pyodbc/compiler.py
@@ -3,6 +3,7 @@ try:
 except ImportError:
     from itertools import izip_longest as zip_longest
 
+from django import VERSION as DjangoVersion
 from django.db.models.sql import compiler
 from django.db.transaction import TransactionManagementError
 from django.utils import six
@@ -272,8 +273,10 @@ class SQLAggregateCompiler(compiler.SQLAggregateCompiler, SQLCompiler):
         self._wrap_aggregates()
         return super(SQLAggregateCompiler, self).as_sql(qn=qn)
 
-class SQLDateCompiler(compiler.SQLDateCompiler, SQLCompiler):
-    pass
+if DjangoVersion[:2] >= (1,8):
+    # SQLDateCompiler and SQLDateTimeCompiler were removed in Django 1.8
+    class SQLDateCompiler(compiler.SQLDateCompiler, SQLCompiler):
+        pass
 
-class SQLDateTimeCompiler(compiler.SQLDateTimeCompiler, SQLCompiler):
-    pass
+    class SQLDateTimeCompiler(compiler.SQLDateTimeCompiler, SQLCompiler):
+        pass

--- a/sql_server/pyodbc/compiler.py
+++ b/sql_server/pyodbc/compiler.py
@@ -274,7 +274,7 @@ class SQLAggregateCompiler(compiler.SQLAggregateCompiler, SQLCompiler):
         self._wrap_aggregates()
         return super(SQLAggregateCompiler, self).as_sql(qn=qn)
 
-if DjangoVersion[:2] >= (1,8):
+if DjangoVersion[:2] <= (1,8):
     # SQLDateCompiler and SQLDateTimeCompiler were removed in Django 1.8
     class SQLDateCompiler(compiler.SQLDateCompiler, SQLCompiler):
         pass

--- a/sql_server/pyodbc/creation.py
+++ b/sql_server/pyodbc/creation.py
@@ -1,45 +1,18 @@
-from django.db.backends.creation import BaseDatabaseCreation
+try:
+    from django.db.backends.base.creation import BaseDatabaseCreation
+except ImportError:
+    from django.db.backends.creation import BaseDatabaseCreation
 from django.db.backends.util import truncate_name
 from django.utils.six import b
 
 
 class DatabaseCreation(BaseDatabaseCreation):
-    # This dictionary maps Field objects to their associated MS SQL column
-    # types, as strings. Column-type strings can contain format strings; they'll
-    # be interpolated against the values of Field.__dict__ before being output.
-    # If a column type is set to None, it won't be included in the output.
-    data_types = {
-        'AutoField':         'int IDENTITY (1, 1)',
-        'BigIntegerField':   'bigint',
-        'BinaryField':       'varbinary(max)',
-        'BooleanField':      'bit',
-        'CharField':         'nvarchar(%(max_length)s)',
-        'CommaSeparatedIntegerField': 'nvarchar(%(max_length)s)',
-        'DateField':         'date',
-        'DateTimeField':     'datetime2',
-        'DecimalField':      'numeric(%(max_digits)s, %(decimal_places)s)',
-        'FileField':         'nvarchar(%(max_length)s)',
-        'FilePathField':     'nvarchar(%(max_length)s)',
-        'FloatField':        'double precision',
-        'IntegerField':      'int',
-        'IPAddressField':    'nvarchar(15)',
-        'GenericIPAddressField': 'nvarchar(39)',
-        'NullBooleanField':  'bit',
-        'OneToOneField':     'int',
-        'PositiveIntegerField': 'int',
-        'PositiveSmallIntegerField': 'smallint',
-        'SlugField':         'nvarchar(%(max_length)s)',
-        'SmallIntegerField': 'smallint',
-        'TextField':         'nvarchar(max)',
-        'TimeField':         'time',
-    }
-
-    data_type_check_constraints = {
-        'PositiveIntegerField': '[%(column)s] >= 0',
-        'PositiveSmallIntegerField': '[%(column)s] >= 0',
-    }
 
     def __init__(self, connection):
+        # For Django versions < 1.8
+        self.data_types = connection.data_types
+        self.data_types_suffix = connection.data_types_suffix
+        self.data_type_check_constraints = connection.data_type_check_constraints
         super(DatabaseCreation, self).__init__(connection)
 
     def _create_test_db(self, verbosity, autoclobber):

--- a/sql_server/pyodbc/introspection.py
+++ b/sql_server/pyodbc/introspection.py
@@ -1,4 +1,7 @@
-from django.db.backends import BaseDatabaseIntrospection, FieldInfo
+try:
+    from django.db.backends.base.introspection import BaseDatabaseIntrospection, FieldInfo
+except ImportError:
+    from django.db.backends import BaseDatabaseIntrospection, FieldInfo
 import pyodbc as Database
 
 SQL_AUTOFIELD = -777555

--- a/sql_server/pyodbc/operations.py
+++ b/sql_server/pyodbc/operations.py
@@ -2,7 +2,10 @@ import datetime
 import time
 
 from django.conf import settings
-from django.db.backends import BaseDatabaseOperations
+try:
+    from django.db.backends.base.operations import BaseDatabaseOperations
+except ImportError:
+    from django.db.backends import BaseDatabaseOperations
 from django.utils import timezone
 from django.utils.six import string_types
 

--- a/sql_server/pyodbc/schema.py
+++ b/sql_server/pyodbc/schema.py
@@ -2,7 +2,10 @@ import binascii
 import datetime
 import operator
 
-from django.db.backends.schema import BaseDatabaseSchemaEditor, logger
+try:
+    from django.db.backends.base.schema import BaseDatabaseSchemaEditor, logger
+except ImportError:
+    from django.db.backends.schema import BaseDatabaseSchemaEditor, logger
 from django.db.models.fields import AutoField
 from django.db.models.fields.related import ManyToManyField
 from django.utils import six


### PR DESCRIPTION
This should fix #22. This definitely needs some checking over, most especially the `date_interval_sql` changes, as I had to operate on a best guess for what is now expected.

One piece I did not handle was a deprecation, [qn replaced by compiler](https://docs.djangoproject.com/en/1.8/releases/1.8/#qn-replaced-by-compiler), since I wasn't entirely sure on this one either, and it's only deprecated so far.
