### PR TITLE
Speed up check_constraints for empty table list

### DIFF
--- a/sql_server/pyodbc/base.py
+++ b/sql_server/pyodbc/base.py
@@ -352,7 +352,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
 
     def _execute_foreach(self, sql, table_names=None):
         cursor = self.cursor()
-        if not table_names:
+        if table_names is None:
             table_names = self.introspection.table_names(cursor)
         for table_name in table_names:
             cursor.execute(sql % self.ops.quote_name(table_name))


### PR DESCRIPTION
Don't run the constraint check against all tables when the loaddata command
passes an empty set of table names, which was mistakenly being interpreted as
equivalent to None - which means "all tables" - when it really means "no
tables".
