### PR TITLE
Don't refuse to talk to SQL Server 2016

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Features
 --------
 
 -  Supports Django 1.8.7
--  Supports Microsoft SQL Server 2005, 2008/2008R2, 2012, 2014 and
+-  Supports Microsoft SQL Server 2005, 2008/2008R2, 2012, 2014, 2016 and
    Azure SQL Database
 -  Supports LIMIT+OFFSET and offset w/o LIMIT emulation.
 -  Passes most of the tests of the Django test suite.

--- a/sql_server/pyodbc/base.py
+++ b/sql_server/pyodbc/base.py
@@ -147,6 +147,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         10: 2008,
         11: 2012,
         12: 2014,
+        13: 2016,
     }
 
     # https://azure.microsoft.com/en-us/documentation/articles/sql-database-develop-csharp-retry-windows/


### PR DESCRIPTION
To enable testing against the SQL Server 2016 Community Tech Previews, we need
to allow connections to be made without raising a

`NotImplementedError('SQL Server v13 is not supported.')`

Tested with latest CTP 3.1 currently available from
[here](https://www.microsoft.com/en-us/evalcenter/evaluate-sql-server-2016)
