### PR TITLE
Obey the connection's TIME_ZONE setting when USE_TZ is enabled

### DIFF
--- a/sql_server/pyodbc/operations.py
+++ b/sql_server/pyodbc/operations.py
@@ -134,7 +134,7 @@ class DatabaseOperations(BaseDatabaseOperations):
                 self._warn_legacy_driver('datetime2')
                 value = datetime.datetime.strptime(value[:26], '%Y-%m-%d %H:%M:%S.%f')
             if settings.USE_TZ:
-                value = timezone.make_aware(value, timezone.utc)
+                value = timezone.make_aware(value, self.connection.timezone)
         return value
 
     def convert_floatfield_value(self, value, expression, connection, context):
@@ -480,7 +480,7 @@ class DatabaseOperations(BaseDatabaseOperations):
             return None
         if settings.USE_TZ and timezone.is_aware(value):
             # pyodbc donesn't support datetimeoffset
-            value = value.astimezone(timezone.utc).replace(tzinfo=None)
+            value = value.astimezone(self.connection.timezone).replace(tzinfo=None)
         if not self.connection.features.supports_microsecond_precision:
             value = value.replace(microsecond=0)
         return value


### PR DESCRIPTION
Given that SQL server has no built-in support for timezones, we have correctly set `DatabaseFeatures.supports_timezones = False`. However, we incorrectly assumed that every datetime stored in the database is in UTC, and have hardcoded `timezone.utc` to be used when making datetimes timezone aware.

Django allows developers to set the `TIME_ZONE` option in a database's connection settings to specify the timezone in which the datetimes are stored, and this library should obey that setting.

See: https://docs.djangoproject.com/en/1.11/ref/settings/#time-zone

To obey the `TIME_ZONE` setting, we replace `timezone.utc` with `self.connection.timezone`, which is a property we inherit from `BaseDatabaseWrapper`. The calculation of that property includes various checks, and will default to `timezone.utc` if no `TIME_ZONE` setting is provided for a database connection - meaning this change will be backward compatible.

See: https://github.com/django/django/blob/1.11.4/django/db/backends/base/base.py#L121-L128