### PR TITLE
Add support for Exists expression

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -234,7 +234,6 @@ Limitations
 The following features are currently not supported:
 
 - Altering a model field from or to AutoField at migration
-- `Exists <https://docs.djangoproject.com/en/1.11/ref/models/expressions/#django.db.models.Exists>`__ subqueries
 
 Notice
 ------

--- a/sql_server/pyodbc/operations.py
+++ b/sql_server/pyodbc/operations.py
@@ -5,7 +5,6 @@ import warnings
 
 from django.conf import settings
 from django.db.backends.base.operations import BaseDatabaseOperations
-from django.db.models.expressions import Exists
 from django.db.models.functions import Greatest, Least
 from django.utils import timezone
 from django.utils.encoding import force_text
@@ -83,13 +82,6 @@ class DatabaseOperations(BaseDatabaseOperations):
                     raise NotImplementedError(
                         'SQL Server has no support for %s function.' %
                         f.function)
-        # SQL Server doesn't allow to use EXISTS in a selection list
-        unsupported_expressions = (Exists, )
-        for e in unsupported_expressions:
-            if isinstance(expression, e):
-                raise NotImplementedError(
-                    "the backend doesn't support %s expression." %
-                    e.__name__)
 
     def combine_duration_expression(self, connector, sub_expressions):
         lhs, rhs = sub_expressions


### PR DESCRIPTION
This add supports for [`Exists`](https://docs.djangoproject.com/en/1.11/ref/models/expressions/#exists-subqueries) using the same method that is used for [Oracle](https://github.com/django/django/blob/1.11.6/django/db/models/expressions.py#L1020-L1026) in Django