### PR TITLE
Work In Progress: Django 2.0 Support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,22 +17,21 @@ Microsoft SQL Server and Azure SQL Database.
 Features
 --------
 
--  Supports Django 1.11.9
--  Supports Microsoft SQL Server 2005, 2008/2008R2, 2012, 2014, 2016, 2017 and
+-  Supports Django 2.0.1
+-  Supports Microsoft SQL Server 2008/2008R2, 2012, 2014, 2016, 2017 and
    Azure SQL Database
--  Supports LIMIT+OFFSET and offset w/o LIMIT emulation.
--  Passes most of the tests of the Django test suite.
+-  Supports LIMIT+OFFSET and offset w/o LIMIT emulation
+-  Passes most of the tests of the Django test suite
 -  Compatible with
-   `Micosoft ODBC Driver for SQL Server <https://msdn.microsoft.com/library/mt654048(v=sql.1).aspx>`__,
-   `SQL Server Native Client <https://msdn.microsoft.com/library/ms130892(v=sql.120).aspx>`__,
-   `SQL Server <https://msdn.microsoft.com/library/aa968814(vs.85).aspx>`__
+   `Micosoft ODBC Driver for SQL Server <https://docs.microsoft.com/en-us/sql/connect/odbc/microsoft-odbc-driver-for-sql-server>`__,
+   `SQL Server Native Client <https://msdn.microsoft.com/en-us/library/ms131321(v=sql.120).aspx>`__,
    and `FreeTDS <http://www.freetds.org/>`__ ODBC drivers.
 
 Dependencies
 ------------
 
--  Django 1.11.9
--  pyodbc 3.0 or newer
+-  Django 2.0.1
+-  pyodbc 4.0 or newer
 
 Installation
 ------------
@@ -124,9 +123,9 @@ Dictionary. Current available keys are:
 
 -  driver
 
-   String. ODBC Driver to use (``"ODBC Driver 11 for SQL Server"`` etc).
-   See http://msdn.microsoft.com/en-us/library/ms130892.aspx. Default is
-   ``"SQL Server"`` on Windows and ``"FreeTDS"`` on other platforms.
+   String. ODBC Driver to use (``"ODBC Driver 13 for SQL Server"``,
+   ``"SQL Server Native Client 11.0"``, ``"FreeTDS"`` etc).
+   Default is ``"ODBC Driver 13 for SQL Server"``.
 
 -  dsn
 
@@ -167,16 +166,6 @@ Dictionary. Current available keys are:
    collation specifier is added to your lookup SQL (the default
    collation of your database will be used). For Chinese language you
    can set it to ``"Chinese_PRC_CI_AS"``.
-
--  use_legacy_datetime
-
-   Boolean. ``DateField``, ``TimeField`` and ``DateTimeField`` of models
-   are mapped to SQL Server's legacy ``datetime`` type if the value is ``True``
-   (the same behavior as the original ``django-pyodbc``). Otherwise, they
-   are mapped to new dedicated data types (``date``, ``time``, ``datetime2``).
-   Default value is ``False``, and note that the feature is always activated
-   when you use SQL Server 2005, or the outdated ODBC drivers (``"FreeTDS"``
-   with TDS protocol v7.2 or earlier/``"SQL Server"``/``"SQL Native Client"``).
 
 -  connection_timeout
 
@@ -238,12 +227,12 @@ The following features are currently not supported:
 Notice
 ------
 
-This version of *django-pyodbc-azure* only supports Django 1.11.
+This version of *django-pyodbc-azure* only supports Django 2.0.
 If you want to use it on older versions of Django,
-specify an appropriate version number (1.10.x.x for Django 1.10)
+specify an appropriate version number (1.11.x.x for Django 1.11)
 at installation like this: ::
 
-    pip install "django-pyodbc-azure<1.11"
+    pip install "django-pyodbc-azure<2.0"
 
 License
 -------

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ Dependencies
 ------------
 
 -  Django 2.0.1
--  pyodbc 4.0 or newer
+-  pyodbc 3.0 or newer
 
 Installation
 ------------

--- a/README.rst
+++ b/README.rst
@@ -243,8 +243,9 @@ Credits
 -------
 
 -  `Ramiro Morales <https://people.djangoproject.com/ramiro/>`__
--  `Filip Wasilewski <http://code.djangoproject.com/ticket/5246>`__
+-  `Filip Wasilewski <https://code.djangoproject.com/ticket/5246>`__
 -  `Wei guangjing <https://people.djangoproject.com/vcc/>`__
--  `mamcx <http://code.djangoproject.com/ticket/5062>`__
--  `Alex Vidal <http://github.com/avidal/>`__
--  `Michiya Takahashi <http://github.com/michiya/>`__
+-  `mamcx <https://code.djangoproject.com/ticket/5062>`__
+-  `Alex Vidal <https://github.com/avidal/>`__
+-  `Michiya Takahashi <https://github.com/michiya/>`__
+-  `Timothy Allen <https://github.com/FlipperPA/>`__

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,6 @@ CLASSIFIERS=[
     'License :: OSI Approved :: BSD License',
     'Framework :: Django',
     'Programming Language :: Python',
-    'Programming Language :: Python :: 2',
-    'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     packages=['sql_server', 'sql_server.pyodbc'],
     install_requires=[
         'Django>=2.0.1,<2.1',
-        'pyodbc>=4.0',
+        'pyodbc>=3.0',
     ],
     classifiers=CLASSIFIERS,
     keywords='azure django',

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ CLASSIFIERS=[
 
 setup(
     name='django-pyodbc-azure',
-    version='1.11.9.0',
+    version='2.0.1.0',
     description='Django backend for Microsoft SQL Server and Azure SQL Database using pyodbc',
     long_description=open('README.rst').read(),
     author='Michiya Takahashi',
@@ -28,8 +28,8 @@ setup(
     license='BSD',
     packages=['sql_server', 'sql_server.pyodbc'],
     install_requires=[
-        'Django>=1.11.9,<2.0',
-        'pyodbc>=3.0',
+        'Django>=2.0.1,<2.1',
+        'pyodbc>=4.0',
     ],
     classifiers=CLASSIFIERS,
     keywords='azure django',

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,10 @@
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
+from setuptools import setup
 
-CLASSIFIERS=[
+CLASSIFIERS = [
     'Development Status :: 4 - Beta',
     'License :: OSI Approved :: BSD License',
     'Framework :: Django',
     'Programming Language :: Python',
-    'Programming Language :: Python :: 2',
-    'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',

--- a/sql_server/pyodbc/base.py
+++ b/sql_server/pyodbc/base.py
@@ -7,7 +7,8 @@ import time
 
 from django.core.exceptions import ImproperlyConfigured
 from django import VERSION
-if VERSION[:3] < (1,11,9) or VERSION[:2] >= (2,0):
+
+if VERSION[:3] < (2,0,1) or VERSION[:2] >= (2,1):
     raise ImproperlyConfigured("Django %d.%d.%d is not supported." % VERSION[:3])
 
 try:
@@ -15,16 +16,18 @@ try:
 except ImportError as e:
     raise ImproperlyConfigured("Error loading pyodbc module: %s" % e)
 
-pyodbc_ver = tuple(map(int, Database.version.split('.')[:2]))
-if pyodbc_ver < (3, 0):
-    raise ImproperlyConfigured("pyodbc 3.0 or newer is required; you have %s" % Database.version)
+from django.utils.version import get_version_tuple
+
+pyodbc_ver = get_version_tuple(Database.version)
+if pyodbc_ver < (4,0):
+    raise ImproperlyConfigured("pyodbc 4.0 or newer is required; you have %s" % Database.version)
 
 from django.conf import settings
+from django.db import NotSupportedError
 from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.backends.base.validation import BaseDatabaseValidation
 from django.utils.encoding import smart_str
 from django.utils.functional import cached_property
-from django.utils.six import binary_type, text_type
 from django.utils.timezone import utc
 
 if hasattr(settings, 'DATABASE_CONNECTION_POOLING'):
@@ -64,6 +67,7 @@ def encode_value(v):
 
 class DatabaseWrapper(BaseDatabaseWrapper):
     vendor = 'microsoft'
+    display_name = 'SQL Server'
     # This dictionary maps Field objects to their associated MS SQL column
     # types, as strings. Column-type strings can contain format strings; they'll
     # be interpolated against the values of Field.__dict__ before being output.
@@ -75,7 +79,6 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         'BinaryField':       'varbinary(max)',
         'BooleanField':      'bit',
         'CharField':         'nvarchar(%(max_length)s)',
-        'CommaSeparatedIntegerField': 'nvarchar(%(max_length)s)',
         'DateField':         'date',
         'DateTimeField':     'datetime2',
         'DecimalField':      'numeric(%(max_digits)s, %(decimal_places)s)',
@@ -149,7 +152,6 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         '08S02',
     )
     _sql_server_versions = {
-        9: 2005,
         10: 2008,
         11: 2012,
         12: 2014,
@@ -171,7 +173,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     )
 
     def __init__(self, *args, **kwargs):
-        super(DatabaseWrapper, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         opts = self.settings_dict["OPTIONS"]
 
@@ -189,9 +191,6 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             self.driver_charset = 'utf-8'
         else:
             self.driver_charset = opts.get('driver_charset', None)
-
-        # data type compatibility to databases created by old django-pyodbc
-        self.use_legacy_datetime = opts.get('use_legacy_datetime', False)
 
         # interval to wait for recovery from network error
         interval = opts.get('connection_recovery_interval_msec', 0.0)
@@ -236,17 +235,14 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         password = conn_params.get('PASSWORD', None)
         port = conn_params.get('PORT', None)
 
-        default_driver = 'SQL Server' if os.name == 'nt' else 'FreeTDS'
         options = conn_params.get('OPTIONS', {})
-        driver = options.get('driver', default_driver)
+        driver = options.get('driver', 'ODBC Driver 13 for SQL Server')
         dsn = options.get('dsn', None)
 
         # Microsoft driver names assumed here are:
-        # * SQL Server
-        # * SQL Native Client
         # * SQL Server Native Client 10.0/11.0
         # * ODBC Driver 11/13 for SQL Server
-        ms_drivers = re.compile('.*SQL (Server$|(Server )?Native Client)')
+        ms_drivers = re.compile('^ODBC Driver .* for SQL Server$|^SQL Server Native Client')
 
         # available ODBC connection string keywords:
         # (Microsoft drivers for Windows)
@@ -284,9 +280,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
 
         cstr_parts['DATABASE'] = database
 
-        if ms_drivers.match(driver) and not driver == 'SQL Server':
-            self.supports_mars = True
-        if self.supports_mars:
+        if ms_drivers.match(driver) and os.name == 'nt':
             cstr_parts['MARS_Connection'] = 'yes'
 
         connstr = encode_connection_string(cstr_parts)
@@ -327,36 +321,25 @@ class DatabaseWrapper(BaseDatabaseWrapper):
 
     def init_connection_state(self):
         drv_name = self.connection.getinfo(Database.SQL_DRIVER_NAME).upper()
-        driver_is_freetds = drv_name.startswith('LIBTDSODBC')
-        driver_is_sqlsrv32 = drv_name == 'SQLSRV32.DLL'
 
-        if driver_is_freetds:
-            self.supports_mars = False
+        if drv_name.startswith('LIBTDSODBC'):
             try:
                 drv_ver = self.connection.getinfo(Database.SQL_DRIVER_VER)
-                ver = tuple(map(int, drv_ver.split('.')[:2]))
+                ver = get_version_tuple(drv_ver.split('.')[:2])
                 if ver < (0, 95):
-                    # FreeTDS can't execute some sql queries like CREATE DATABASE etc.
-                    # in multi-statement, so we need to commit the above SQL sentence(s)
-                    # to avoid this
-                    self.connection.commit()
+                    raise ImproperlyConfigured(
+                        "FreeTDS 0.95 or newer is required.")
             except:
                 # unknown driver version
                 pass
-        elif driver_is_sqlsrv32:
-            self.supports_mars = False
 
-        ms_drv_names = re.compile('^(LIB)?(SQLN?CLI|MSODBCSQL)')
+        ms_drv_names = re.compile('^(LIB)?(SQLNCLI|MSODBCSQL)')
 
-        if driver_is_sqlsrv32 or ms_drv_names.match(drv_name):
+        if ms_drv_names.match(drv_name):
             self.driver_charset = None
-
-        # http://msdn.microsoft.com/en-us/library/ms131686.aspx
-        if self.supports_mars and ms_drv_names.match(drv_name):
+            # http://msdn.microsoft.com/en-us/library/ms131686.aspx
+            self.supports_mars = True
             self.features.can_use_chunked_reads = True
-
-        if self.sql_server_version < 2008:
-            self.features.has_bulk_insert = False
 
         settings_dict = self.settings_dict
         cursor = self.create_cursor()
@@ -370,17 +353,10 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         cursor.execute('SET DATEFORMAT ymd; SET DATEFIRST %s' % datefirst)
 
         # http://blogs.msdn.com/b/sqlnativeclient/archive/2008/02/27/microsoft-sql-server-native-client-and-microsoft-sql-server-2008-native-client.aspx
-        try:
-            val = cursor.execute('SELECT SYSDATETIME()').fetchone()[0]
-            if isinstance(val, text_type):
-                # the driver doesn't support the modern datetime types
-                self.use_legacy_datetime = True
-        except:
-            # the server doesn't support the modern datetime types
-            self.use_legacy_datetime = True
-        if self.use_legacy_datetime:
-            self._use_legacy_datetime()
-            self.features.supports_microsecond_precision = False
+        val = cursor.execute('SELECT SYSDATETIME()').fetchone()[0]
+        if isinstance(val, str):
+            raise ImproperlyConfigured(
+                "The database driver doesn't support modern datatime types.")
 
     def is_usable(self):
         try:
@@ -401,7 +377,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             ver = cursor.fetchone()[0]
             ver = int(ver.split('.')[0])
             if not ver in self._sql_server_versions:
-                raise NotImplementedError('SQL Server v%d is not supported.' % ver)
+                raise NotSupportedError('SQL Server v%d is not supported.' % ver)
             return self._sql_server_versions[ver]
 
     @cached_property
@@ -446,7 +422,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
 
     def _savepoint_rollback(self, sid):
         with self.cursor() as cursor:
-            # FreeTDS v0.95 requires TRANCOUNT that is greater than 0
+            # FreeTDS requires TRANCOUNT that is greater than 0
             cursor.execute('SELECT @@TRANCOUNT')
             trancount = cursor.fetchone()[0]
             if trancount > 0:
@@ -456,14 +432,10 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         with self.wrap_database_errors:
             allowed = not autocommit
             if not allowed:
-                # FreeTDS v0.95 requires TRANCOUNT that is greater than 0
+                # FreeTDS requires TRANCOUNT that is greater than 0
                 allowed = self._get_trancount() > 0
             if allowed:
                 self.connection.autocommit = autocommit
-
-    def _use_legacy_datetime(self):
-        for field in ('DateField', 'DateTimeField', 'TimeField'):
-            self.data_types[field] = 'datetime'
 
     def check_constraints(self, table_names=None):
         self._execute_foreach('ALTER TABLE %s WITH CHECK CHECK CONSTRAINT ALL',
@@ -502,7 +474,7 @@ class CursorWrapper(object):
             self.cursor.close()
 
     def format_sql(self, sql, params):
-        if self.driver_charset and isinstance(sql, text_type):
+        if self.driver_charset and isinstance(sql, str):
             # FreeTDS (and other ODBC drivers?) doesn't support Unicode
             # yet, so we need to encode the SQL clause itself in utf-8
             sql = smart_str(sql, self.driver_charset)
@@ -517,7 +489,7 @@ class CursorWrapper(object):
         fp = []
         if params is not None:
             for p in params:
-                if isinstance(p, text_type):
+                if isinstance(p, str):
                     if self.driver_charset:
                         # FreeTDS (and other ODBC drivers?) doesn't support Unicode
                         # yet, so we need to encode parameters in utf-8
@@ -525,7 +497,7 @@ class CursorWrapper(object):
                     else:
                         fp.append(p)
 
-                elif isinstance(p, binary_type):
+                elif isinstance(p, bytes):
                     fp.append(p)
 
                 elif isinstance(p, type(True)):
@@ -568,16 +540,16 @@ class CursorWrapper(object):
     def format_row(self, row):
         """
         Decode data coming from the database if needed and convert rows to tuples
-        (pyodbc Rows are not sliceable).
+        (pyodbc Rows are not hashable).
         """
         if self.driver_charset:
             for i in range(len(row)):
                 f = row[i]
                 # FreeTDS (and other ODBC drivers?) doesn't support Unicode
                 # yet, so we need to decode utf-8 data coming from the DB
-                if isinstance(f, binary_type):
+                if isinstance(f, bytes):
                     row[i] = f.decode(self.driver_charset)
-        return row
+        return tuple(row)
 
     def fetchone(self):
         row = self.cursor.fetchone()
@@ -585,7 +557,8 @@ class CursorWrapper(object):
             row = self.format_row(row)
         # Any remaining rows in the current set must be discarded
         # before changing autocommit mode when you use FreeTDS
-        self.cursor.nextset()
+        if not self.connection.supports_mars:
+            self.cursor.nextset()
         return row
 
     def fetchmany(self, chunk):

--- a/sql_server/pyodbc/base.py
+++ b/sql_server/pyodbc/base.py
@@ -19,8 +19,8 @@ except ImportError as e:
 from django.utils.version import get_version_tuple
 
 pyodbc_ver = get_version_tuple(Database.version)
-if pyodbc_ver < (4,0):
-    raise ImproperlyConfigured("pyodbc 4.0 or newer is required; you have %s" % Database.version)
+if pyodbc_ver < (3,0):
+    raise ImproperlyConfigured("pyodbc 3.0 or newer is required; you have %s" % Database.version)
 
 from django.conf import settings
 from django.db import NotSupportedError

--- a/sql_server/pyodbc/client.py
+++ b/sql_server/pyodbc/client.py
@@ -2,6 +2,7 @@ import re
 
 from django.db.backends.base.client import BaseDatabaseClient
 
+
 class DatabaseClient(BaseDatabaseClient):
     executable_name = 'sqlcmd'
 
@@ -19,7 +20,6 @@ class DatabaseClient(BaseDatabaseClient):
         if self.executable_name == 'sqlcmd':
             db = options.get('db', settings_dict['NAME'])
             server = options.get('host', settings_dict['HOST'])
-            port = options.get('port', settings_dict['PORT'])
             defaults_file = options.get('read_default_file')
 
             args = [self.executable_name]
@@ -30,7 +30,7 @@ class DatabaseClient(BaseDatabaseClient):
                 if password:
                     args += ["-P", password]
             else:
-                args += ["-E"] # Try trusted connection instead
+                args += ["-E"]  # Try trusted connection instead
             if db:
                 args += ["-d", db]
             if defaults_file:

--- a/sql_server/pyodbc/creation.py
+++ b/sql_server/pyodbc/creation.py
@@ -15,7 +15,7 @@ class DatabaseCreation(BaseDatabaseCreation):
             to_azure_sql_db = self.connection.to_azure_sql_db
             if not to_azure_sql_db:
                 cursor.execute("ALTER DATABASE %s SET SINGLE_USER WITH ROLLBACK IMMEDIATE"
-                                % self.connection.ops.quote_name(test_database_name))
+                               % self.connection.ops.quote_name(test_database_name))
             cursor.execute("DROP DATABASE %s"
                            % self.connection.ops.quote_name(test_database_name))
 

--- a/sql_server/pyodbc/features.py
+++ b/sql_server/pyodbc/features.py
@@ -1,8 +1,3 @@
-try:
-    import pytz
-except ImportError:
-    pytz = None
-
 from django.db.backends.base.features import BaseDatabaseFeatures
 
 
@@ -13,16 +8,14 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     can_return_id_from_insert = True
     can_use_chunked_reads = False
     for_update_after_from = True
-    has_bulk_insert = True
     has_real_datatype = True
     has_select_for_update = True
     has_select_for_update_nowait = True
-    has_zoneinfo_database = pytz is not None
+    has_zoneinfo_database = False
     ignores_table_name_case = True
     ignores_quoted_identifier_case = True
     requires_literal_defaults = True
     requires_sqlparse_for_splitting = False
-    supports_1000_query_parameters = False
     supports_nullable_unique_constraints = False
     supports_paramstyle_pyformat = False
     supports_partially_nullable_unique_constraints = False

--- a/sql_server/pyodbc/introspection.py
+++ b/sql_server/pyodbc/introspection.py
@@ -15,32 +15,32 @@ SQL_BIGAUTOFIELD = -777444
 class DatabaseIntrospection(BaseDatabaseIntrospection):
     # Map type codes to Django Field types.
     data_types_reverse = {
-        SQL_AUTOFIELD:                  'AutoField',
-        SQL_BIGAUTOFIELD:               'BigAutoField',
-        Database.SQL_BIGINT:            'BigIntegerField',
-        #Database.SQL_BINARY:            ,
-        Database.SQL_BIT:               'BooleanField',
-        Database.SQL_CHAR:              'CharField',
-        Database.SQL_DECIMAL:           'DecimalField',
-        Database.SQL_DOUBLE:            'FloatField',
-        Database.SQL_FLOAT:             'FloatField',
-        Database.SQL_GUID:              'TextField',
-        Database.SQL_INTEGER:           'IntegerField',
-        Database.SQL_LONGVARBINARY:     'BinaryField',
-        #Database.SQL_LONGVARCHAR:       ,
-        Database.SQL_NUMERIC:           'DecimalField',
-        Database.SQL_REAL:              'FloatField',
-        Database.SQL_SMALLINT:          'SmallIntegerField',
-        Database.SQL_SS_TIME2:          'TimeField',
-        Database.SQL_TINYINT:           'SmallIntegerField',
-        Database.SQL_TYPE_DATE:         'DateField',
-        Database.SQL_TYPE_TIME:         'TimeField',
-        Database.SQL_TYPE_TIMESTAMP:    'DateTimeField',
-        Database.SQL_VARBINARY:         'BinaryField',
-        Database.SQL_VARCHAR:           'TextField',
-        Database.SQL_WCHAR:             'CharField',
-        Database.SQL_WLONGVARCHAR:      'TextField',
-        Database.SQL_WVARCHAR:          'TextField',
+        SQL_AUTOFIELD: 'AutoField',
+        SQL_BIGAUTOFIELD: 'BigAutoField',
+        Database.SQL_BIGINT: 'BigIntegerField',
+        # Database.SQL_BINARY: ,
+        Database.SQL_BIT: 'BooleanField',
+        Database.SQL_CHAR: 'CharField',
+        Database.SQL_DECIMAL: 'DecimalField',
+        Database.SQL_DOUBLE: 'FloatField',
+        Database.SQL_FLOAT: 'FloatField',
+        Database.SQL_GUID: 'TextField',
+        Database.SQL_INTEGER: 'IntegerField',
+        Database.SQL_LONGVARBINARY: 'BinaryField',
+        # Database.SQL_LONGVARCHAR: ,
+        Database.SQL_NUMERIC: 'DecimalField',
+        Database.SQL_REAL: 'FloatField',
+        Database.SQL_SMALLINT: 'SmallIntegerField',
+        Database.SQL_SS_TIME2: 'TimeField',
+        Database.SQL_TINYINT: 'SmallIntegerField',
+        Database.SQL_TYPE_DATE: 'DateField',
+        Database.SQL_TYPE_TIME: 'TimeField',
+        Database.SQL_TYPE_TIMESTAMP: 'DateTimeField',
+        Database.SQL_VARBINARY: 'BinaryField',
+        Database.SQL_VARCHAR: 'TextField',
+        Database.SQL_WCHAR: 'CharField',
+        Database.SQL_WLONGVARCHAR: 'TextField',
+        Database.SQL_WVARCHAR: 'TextField',
     }
 
     ignored_tables = []
@@ -51,10 +51,10 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         # (it depends on the driver)
         size = description.internal_size
         if field_type == 'CharField':
-            if size == 0 or size >= 2**30-1:
+            if size == 0 or size >= 2 ** 30 - 1:
                 field_type = "TextField"
         elif field_type == 'TextField':
-            if size > 0 and size < 2**30-1:
+            if size > 0 and size < 2 ** 30 - 1:
                 field_type = 'CharField'
         return field_type
 
@@ -75,11 +75,11 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         """
         # COLUMNPROPERTY: http://msdn2.microsoft.com/en-us/library/ms174968.aspx
 
-        #from django.db import connection
-        #cursor.execute("SELECT COLUMNPROPERTY(OBJECT_ID(%s), %s, 'IsIdentity')",
+        # from django.db import connection
+        # cursor.execute("SELECT COLUMNPROPERTY(OBJECT_ID(%s), %s, 'IsIdentity')",
         #                 (connection.ops.quote_name(table_name), column_name))
         cursor.execute("SELECT COLUMNPROPERTY(OBJECT_ID(%s), %s, 'IsIdentity')",
-                         (self.connection.ops.quote_name(table_name), column_name))
+                       (self.connection.ops.quote_name(table_name), column_name))
         return cursor.fetchall()[0][0]
 
     def get_table_description(self, cursor, table_name, identity_check=True):
@@ -111,11 +111,14 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         return items
 
     def get_sequences(self, cursor, table_name, table_fields=()):
-        cursor.execute("""
+        cursor.execute(
+            """
             SELECT c.name FROM sys.columns c
             INNER JOIN sys.tables t ON c.object_id = t.object_id
-            WHERE t.name = %s AND c.is_identity = 1""",
-            [table_name])
+            WHERE t.name = %s AND c.is_identity = 1
+            """,
+            [table_name]
+        )
         # SQL Server allows only one identity column per table
         # https://docs.microsoft.com/en-us/sql/t-sql/statements/create-table-transact-sql-identity-property
         row = cursor.fetchone()
@@ -211,7 +214,7 @@ AND t.name = %s"""
         for field in field_names:
             val = results.get(field, None)
             if val:
-                indexes[field] = dict(primary_key=(val=='PRIMARY KEY'), unique=(val=='UNIQUE'))
+                indexes[field] = dict(primary_key=(val == 'PRIMARY KEY'), unique=(val == 'UNIQUE'))
 
         return indexes
 
@@ -371,7 +374,7 @@ AND t.name = %s"""
                     "check": False,
                     "index": True,
                     "orders": [],
-                    "type": Index.suffix if type_ in (1,2) else desc.lower(),
+                    "type": Index.suffix if type_ in (1, 2) else desc.lower(),
                 }
             indexes[index]["columns"].append(column)
             indexes[index]["orders"].append("DESC" if order == 1 else "ASC")

--- a/sql_server/pyodbc/operations.py
+++ b/sql_server/pyodbc/operations.py
@@ -1,14 +1,11 @@
 import datetime
-import time
 import uuid
 import warnings
 
 from django.conf import settings
 from django.db.backends.base.operations import BaseDatabaseOperations
-from django.db.models.functions import Greatest, Least
 from django.utils import timezone
 from django.utils.encoding import force_text
-from django.utils.six import string_types
 
 import pytz
 
@@ -16,11 +13,13 @@ import pytz
 class DatabaseOperations(BaseDatabaseOperations):
     compiler_module = 'sql_server.pyodbc.compiler'
 
+    cast_char_field_without_max_length = 'nvarchar(max)'
+
     def _convert_field_to_tz(self, field_name, tzname):
         if settings.USE_TZ and not tzname == 'UTC':
             offset = self._get_utcoffset(tzname)
             field_name = 'DATEADD(second, %d, %s)' % (offset, field_name)
-        return field_name, []
+        return field_name
 
     def _get_utcoffset(self, tzname):
         """
@@ -33,15 +32,6 @@ class DatabaseOperations(BaseDatabaseOperations):
         now = datetime.datetime.now()
         delta = zone.localize(now, is_dst=False).utcoffset()
         return delta.days * 86400 + delta.seconds
-
-    def _warn_legacy_driver(self, sqltype):
-        warnings.warn(
-            'A %s value was received as a string. This is because you '
-            'are now using a legacy ODBC driver which does not support '
-            'this data type while your database has been migrated using it. '
-            'You should upgrade your ODBC driver for consistency with your '
-            'database migration.' % sqltype,
-            RuntimeWarning)
 
     def bulk_batch_size(self, fields, objs):
         """
@@ -73,16 +63,6 @@ class DatabaseOperations(BaseDatabaseOperations):
                "ROW_NUMBER() OVER (ORDER BY cache_key) AS rn FROM %s" \
                ") cache WHERE rn = %%s + 1"
 
-    def check_expression_support(self, expression):
-        if self.connection.sql_server_version < 2008:
-            # we can't even emulate GREATEST nor LEAST
-            unsupported_functions = (Greatest, Least)
-            for f in unsupported_functions:
-                if isinstance(expression, f):
-                    raise NotImplementedError(
-                        'SQL Server has no support for %s function.' %
-                        f.function)
-
     def combine_duration_expression(self, connector, sub_expressions):
         lhs, rhs = sub_expressions
         sign = ' * -1' if connector == '-' else ''
@@ -104,58 +84,25 @@ class DatabaseOperations(BaseDatabaseOperations):
             return '%s * (2 * %s)' % tuple(sub_expressions)
         elif connector == '>>':
             return '%s / (2 * %s)' % tuple(sub_expressions)
-        return super(DatabaseOperations, self).combine_expression(connector, sub_expressions)
+        return super().combine_expression(connector, sub_expressions)
 
-    def convert_datefield_value(self, value, expression, connection, context):
+    def convert_datetimefield_value(self, value, expression, connection):
         if value is not None:
-            # WDAC and old FreeTDS receive a date value as a string
-            # http://blogs.msdn.com/b/sqlnativeclient/archive/2008/02/27/microsoft-sql-server-native-client-and-microsoft-sql-server-2008-native-client.aspx
-            if isinstance(value, string_types):
-                self._warn_legacy_driver('date')
-                value = datetime.date(*map(lambda x: int(x), value.split('-')))
-            elif self.connection.use_legacy_datetime:
-                if isinstance(value, datetime.datetime):
-                    value = value.date() # extract date
-        return value
-
-    def convert_datetimefield_value(self, value, expression, connection, context):
-        if value is not None:
-            # WDAC and old FreeTDS receive a datetime2 value as a string
-            # http://blogs.msdn.com/b/sqlnativeclient/archive/2008/02/27/microsoft-sql-server-native-client-and-microsoft-sql-server-2008-native-client.aspx
-            if isinstance(value, string_types):
-                self._warn_legacy_driver('datetime2')
-                value = datetime.datetime.strptime(value[:26], '%Y-%m-%d %H:%M:%S.%f')
             if settings.USE_TZ:
                 value = timezone.make_aware(value, timezone.utc)
         return value
 
-    def convert_floatfield_value(self, value, expression, connection, context):
+    def convert_floatfield_value(self, value, expression, connection):
         if value is not None:
             value = float(value)
         return value
 
-    def convert_timefield_value(self, value, expression, connection, context):
-        if value is not None:
-            # WDAC and old FreeTDS receive a time value as a string
-            # http://blogs.msdn.com/b/sqlnativeclient/archive/2008/02/27/microsoft-sql-server-native-client-and-microsoft-sql-server-2008-native-client.aspx
-            if isinstance(value, string_types):
-                self._warn_legacy_driver('time')
-                value = datetime.time(*map(lambda x: int(x), value[:15].replace('.', ':').split(':')))
-            elif self.connection.use_legacy_datetime:
-                if (isinstance(value, datetime.datetime) and value.year == 1900 and value.month == value.day == 1):
-                    value = value.time() # extract time
-        return value
-
-    def convert_uuidfield_value(self, value, expression, connection, context):
+    def convert_uuidfield_value(self, value, expression, connection):
         if value is not None:
             value = uuid.UUID(value)
         return value
 
     def date_extract_sql(self, lookup_type, field_name):
-        """
-        Given a lookup_type of 'year', 'month', 'day' or 'week_day', returns
-        the SQL that extracts a value from the given date field field_name.
-        """
         if lookup_type == 'week_day':
             return "DATEPART(dw, %s)" % field_name
         else:
@@ -166,65 +113,49 @@ class DatabaseOperations(BaseDatabaseOperations):
         implements the interval functionality for expressions
         """
         sec = timedelta.seconds + timedelta.days * 86400
-        sql = 'DATEADD(second, %d%%s, CAST(%%s AS datetime))' % sec
+        sql = 'DATEADD(second, %d%%s, CAST(%%s AS datetime2))' % sec
         if timedelta.microseconds:
-            if self.connection.use_legacy_datetime:
-                sql = 'DATEADD(millisecond, %d%%s, CAST(%s AS datetime))' % (timedelta.microseconds // 1000, sql)
-            else:
-                sql = 'DATEADD(microsecond, %d%%s, CAST(%s AS datetime2))' % (timedelta.microseconds, sql)
-        return sql, ()
+            sql = 'DATEADD(microsecond, %d%%s, CAST(%s AS datetime2))' % (timedelta.microseconds, sql)
+        return sql
 
     def date_trunc_sql(self, lookup_type, field_name):
-        """
-        Given a lookup_type of 'year', 'month' or 'day', returns the SQL that
-        truncates the given date field field_name to a date object with only
-        the given specificity.
-        """
         if lookup_type == 'year':
-            return "CONVERT(datetime, CONVERT(varchar, DATEPART(year, %s)) + '/01/01')" % field_name
+            return "CONVERT(datetime2, CONVERT(varchar, DATEPART(year, %s)) + '/01/01')" % field_name
+        if lookup_type == 'quarter':
+            return "CONVERT(datetime2, CONVERT(varchar, DATEPART(year, %s)) + '/' + CONVERT(varchar, 1+((DATEPART(quarter, %s)-1)*3)) + '/01')" % (field_name, field_name)
         if lookup_type == 'month':
-            return "CONVERT(datetime, CONVERT(varchar, DATEPART(year, %s)) + '/' + CONVERT(varchar, DATEPART(month, %s)) + '/01')" % (field_name, field_name)
+            return "CONVERT(datetime2, CONVERT(varchar, DATEPART(year, %s)) + '/' + CONVERT(varchar, DATEPART(month, %s)) + '/01')" % (field_name, field_name)
         if lookup_type == 'day':
-            return "CONVERT(datetime, CONVERT(varchar(12), %s, 112))" % field_name
+            return "CONVERT(datetime2, CONVERT(varchar(12), %s, 112))" % field_name
 
     def datetime_cast_date_sql(self, field_name, tzname):
-        field_name, params = self._convert_field_to_tz(field_name, tzname)
-        if self.connection.use_legacy_datetime:
-            sql = 'CONVERT(datetime, CONVERT(char(10), %s, 101), 101)' % field_name
-        else:
-            sql = 'CAST(%s AS date)' % field_name
-        return sql, params
+        field_name = self._convert_field_to_tz(field_name, tzname)
+        sql = 'CAST(%s AS date)' % field_name
+        return sql
 
     def datetime_cast_time_sql(self, field_name, tzname):
-        field_name, params = self._convert_field_to_tz(field_name, tzname)
-        if self.connection.use_legacy_datetime:
-            sql = 'CONVERT(datetime, %s)' % field_name
-        else:
-            sql = 'CAST(%s AS time)' % field_name
-        return sql, params
+        field_name = self._convert_field_to_tz(field_name, tzname)
+        sql = 'CAST(%s AS time)' % field_name
+        return sql
 
     def datetime_extract_sql(self, lookup_type, field_name, tzname):
-        field_name, params = self._convert_field_to_tz(field_name, tzname)
-        sql = self.date_extract_sql(lookup_type, field_name)
-        return sql, params
+        field_name = self._convert_field_to_tz(field_name, tzname)
+        return self.date_extract_sql(lookup_type, field_name)
 
     def datetime_trunc_sql(self, lookup_type, field_name, tzname):
-        field_name, params = self._convert_field_to_tz(field_name, tzname)
+        field_name = self._convert_field_to_tz(field_name, tzname)
         sql = ''
-        if lookup_type in ('year', 'month', 'day'):
+        if lookup_type in ('year', 'quarter', 'month', 'day'):
             sql = self.date_trunc_sql(lookup_type, field_name)
         elif lookup_type == 'hour':
-            sql = "CONVERT(datetime, SUBSTRING(CONVERT(varchar, %s, 20), 0, 14) + ':00:00')" % field_name
+            sql = "CONVERT(datetime2, SUBSTRING(CONVERT(varchar, %s, 20), 0, 14) + ':00:00')" % field_name
         elif lookup_type == 'minute':
-            sql = "CONVERT(datetime, SUBSTRING(CONVERT(varchar, %s, 20), 0, 17) + ':00')" % field_name
+            sql = "CONVERT(datetime2, SUBSTRING(CONVERT(varchar, %s, 20), 0, 17) + ':00')" % field_name
         elif lookup_type == 'second':
-            sql = "CONVERT(datetime, CONVERT(varchar, %s, 20))" % field_name
-        return sql, params
+            sql = "CONVERT(datetime2, CONVERT(varchar, %s, 20))" % field_name
+        return sql
 
-    def for_update_sql(self, nowait=False, skip_locked=False):
-        """
-        Returns the FOR UPDATE SQL clause to lock rows for an update operation.
-        """
+    def for_update_sql(self, nowait=False, skip_locked=False, of=()):
         if skip_locked:
             return 'WITH (NOLOCK)'
         elif nowait:
@@ -235,17 +166,11 @@ class DatabaseOperations(BaseDatabaseOperations):
     def format_for_duration_arithmetic(self, sql):
         if sql == '%s':
             # use DATEADD only once because Django prepares only one parameter for this 
-            if self.connection.use_legacy_datetime:
-                fmt = 'DATEADD(second, %s / 1000000%%s, CAST(%%s AS datetime))'
-            else:
-                fmt = 'DATEADD(second, %s / 1000000%%s, CAST(%%s AS datetime2))'
+            fmt = 'DATEADD(second, %s / 1000000%%s, CAST(%%s AS datetime2))'
             sql = '%%s'
         else:
             # use DATEADD twice to avoid arithmetic overflow for number part
-            if self.connection.use_legacy_datetime:
-                fmt = 'DATEADD(second, %s / 1000000%%s, DATEADD(millisecond, %s / 1000 %%%%%%%% 1000%%s, CAST(%%s AS datetime)))'
-            else:
-                fmt = 'DATEADD(second, %s / 1000000%%s, DATEADD(microsecond, %s %%%%%%%% 1000000%%s, CAST(%%s AS datetime2)))'
+            fmt = 'DATEADD(second, %s / 1000000%%s, DATEADD(microsecond, %s %%%%%%%% 1000000%%s, CAST(%%s AS datetime2)))'
             sql = (sql, sql)
         return fmt % sql
 
@@ -258,16 +183,12 @@ class DatabaseOperations(BaseDatabaseOperations):
         return 'CONTAINS(%s, %%s)' % field_name
 
     def get_db_converters(self, expression):
-        converters = super(DatabaseOperations, self).get_db_converters(expression)
+        converters = super().get_db_converters(expression)
         internal_type = expression.output_field.get_internal_type()
-        if internal_type == 'DateField':
-            converters.append(self.convert_datefield_value)
-        elif internal_type == 'DateTimeField':
+        if internal_type == 'DateTimeField':
             converters.append(self.convert_datetimefield_value)
         elif internal_type == 'FloatField':
             converters.append(self.convert_floatfield_value)
-        elif internal_type == 'TimeField':
-            converters.append(self.convert_timefield_value)
         elif internal_type == 'UUIDField':
             converters.append(self.convert_uuidfield_value)
         return converters
@@ -349,7 +270,7 @@ class DatabaseOperations(BaseDatabaseOperations):
         exists for database backends to provide a better implementation
         according to their own quoting schemes.
         """
-        return super(DatabaseOperations, self).last_executed_query(cursor, cursor.last_sql, cursor.last_params)
+        return super().last_executed_query(cursor, cursor.last_sql, cursor.last_params)
 
     def savepoint_create_sql(self, sid):
         """
@@ -473,55 +394,20 @@ class DatabaseOperations(BaseDatabaseOperations):
         if settings.USE_TZ and timezone.is_aware(value):
             # pyodbc donesn't support datetimeoffset
             value = value.astimezone(timezone.utc).replace(tzinfo=None)
-        if not self.connection.features.supports_microsecond_precision:
-            value = value.replace(microsecond=0)
-        return value
-
-    def adapt_timefield_value(self, value):
-        """
-        Transforms a time value to an object compatible with what is expected
-        by the backend driver for time columns.
-        """
-        if value is None:
-            return None
-        if self.connection.use_legacy_datetime:
-            # SQL Server's datetime type doesn't support microseconds
-            if isinstance(value, string_types):
-                value = datetime.datetime(*(time.strptime(value, '%H:%M:%S')[:6]))
-            else:
-                value = datetime.datetime(1900, 1, 1, value.hour, value.minute, value.second)
         return value
 
     def time_trunc_sql(self, lookup_type, field_name):
-        if self.connection.use_legacy_datetime:
-            sql = self.datetime_trunc_sql(lookup_type, field_name, 'UTC')
-        #elif self.connection.sql_server_version >= 2012:
+        #if self.connection.sql_server_version >= 2012:
         #    fields = {
         #        'hour': 'DATEPART(hour, %s)' % field_name,
         #        'minute': 'DATEPART(minute, %s)' % field_name if lookup_type != 'hour' else '0',
         #        'second': 'DATEPART(second, %s)' % field_name if lookup_type == 'second' else '0',
         #    }
         #    sql = 'TIMEFROMPARTS(%(hour)s, %(minute)s, %(second)s, 0, 0)' % fields
-        else:
-            if lookup_type == 'hour':
-                sql = "CONVERT(time, SUBSTRING(CONVERT(varchar, %s, 114), 0, 3) + ':00:00')" % field_name
-            elif lookup_type == 'minute':
-                sql = "CONVERT(time, SUBSTRING(CONVERT(varchar, %s, 114), 0, 6) + ':00')" % field_name
-            elif lookup_type == 'second':
-                sql = "CONVERT(time, SUBSTRING(CONVERT(varchar, %s, 114), 0, 9))" % field_name
+        if lookup_type == 'hour':
+            sql = "CONVERT(time, SUBSTRING(CONVERT(varchar, %s, 114), 0, 3) + ':00:00')" % field_name
+        elif lookup_type == 'minute':
+            sql = "CONVERT(time, SUBSTRING(CONVERT(varchar, %s, 114), 0, 6) + ':00')" % field_name
+        elif lookup_type == 'second':
+            sql = "CONVERT(time, SUBSTRING(CONVERT(varchar, %s, 114), 0, 9))" % field_name
         return sql
-
-    def year_lookup_bounds_for_date_field(self, value):
-        """
-        Returns a two-elements list with the lower and upper bound to be used
-        with a BETWEEN operator to query a DateField value using a year
-        lookup.
-
-        `value` is an int, containing the looked-up year.
-        """
-        if self.connection.use_legacy_datetime:
-            bounds = super(DatabaseOperations, self).year_lookup_bounds_for_datetime_field(value)
-            bounds = [dt.replace(microsecond=0) for dt in bounds]
-        else:
-            bounds = super(DatabaseOperations, self).year_lookup_bounds_for_date_field(value)
-        return bounds

--- a/sql_server/pyodbc/schema.py
+++ b/sql_server/pyodbc/schema.py
@@ -9,7 +9,6 @@ from django.db.backends.ddl_references import (
 )
 from django.db.models import Index
 from django.db.models.fields import AutoField, BigAutoField
-from django.db.models.fields.related import ManyToManyField
 from django.db.transaction import TransactionManagementError
 from django.utils.encoding import force_text
 
@@ -588,7 +587,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             self._sql_select_foreign_key_constraints % {
                 "table": self.quote_value(model._meta.db_table),
             },
-            has_result = True
+            has_result=True
         )
         if result:
             for table, constraint in result:


### PR DESCRIPTION
This is a start of support for Django 2.0. There's still a fair amount of work that needs to be done.

Summary of changes so far:

- Remove `six` and Python 2.7 shims, as we only need to support Python 3.
- Add a "display_name"
- Change methods to receive `models` and `tables` as has been changed for 2.0.
- Python 3 string and byte detection only
- Switch to using the new DDL query models
- Refactor %s to ? replacement
- Touch up PEP-8 in places

What it does:

- `pip installs` successfully and requires Django > 2.0
- Doesn't error when on a fresh Django project (`django-admin.py startproject`) when you `runserver`
- Successfully runs the initial 14 migrations in SQL Server with `python manage.py migrate`

It's a start at least, I'll continue to work on it as I can.