### PR TITLE
sqlcmd should be started with shell=False

### DIFF
--- a/sql_server/pyodbc/client.py
+++ b/sql_server/pyodbc/client.py
@@ -35,12 +35,14 @@ class DatabaseClient(BaseDatabaseClient):
                 args += ["-d", db]
             if defaults_file:
                 args += ["-i", defaults_file]
+            shell = False
         else:
             dsn = options.get('dsn', '')
             args = ['%s -v %s %s %s' % (self.executable_name, dsn, user, password)]
+            shell = True
 
         import subprocess
         try:
-            subprocess.call(args, shell=True)
+            subprocess.call(args, shell=shell)
         except KeyboardInterrupt:
             pass


### PR DESCRIPTION
When passing args as list to subprocess.call if the shell is True, the command arguments are not passed on. While using sqlcmd via dbshell, currently, it is executing without any arguments and hence just displays a help message without opening the sqlcmd shell.
This PR fixes that.