### PR TITLE
Support unique nullable constraints

### DIFF
--- a/sql_server/pyodbc/features.py
+++ b/sql_server/pyodbc/features.py
@@ -16,7 +16,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     ignores_quoted_identifier_case = True
     requires_literal_defaults = True
     requires_sqlparse_for_splitting = False
-    supports_nullable_unique_constraints = False
+    supports_nullable_unique_constraints = True
     supports_paramstyle_pyformat = False
     supports_partially_nullable_unique_constraints = False
     supports_regex_backreferencing = False

--- a/sql_server/pyodbc/schema.py
+++ b/sql_server/pyodbc/schema.py
@@ -52,6 +52,8 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
     sql_delete_table = "DROP TABLE %(table)s"
     sql_rename_column = "EXEC sp_rename '%(table)s.%(old_column)s', %(new_column)s, 'COLUMN'"
     sql_rename_table = "EXEC sp_rename %(old_table)s, %(new_table)s"
+    sql_create_unique_null = "CREATE UNIQUE INDEX %(name)s ON %(table)s(%(columns)s) " \
+                             "WHERE %(columns)s IS NOT NULL"
 
     def _alter_column_default_sql(self, model, old_field, new_field, drop=False):
         """
@@ -307,9 +309,13 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         if post_actions:
             for sql, params in post_actions:
                 self.execute(sql, params)
-        # Added a unique?
         if not old_field.unique and new_field.unique:
-            self.execute(self._create_unique_sql(model, [new_field.column]))
+            if new_field.null:
+                self.execute(
+                    self._create_index_sql(model, [new_field], sql=self.sql_create_unique_null, suffix="_uniq")
+                )
+            else:
+                self.execute(self._create_unique_sql(model, [new_field.column]))
         # Added an index?
         # constraint will no longer be used in lieu of an index. The following
         # lines from the truth table show all True cases; the rest are False:
@@ -483,6 +489,10 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         # It might not actually have a column behind it
         if definition is None:
             return
+        if field.null and field.unique:
+            definition = definition.replace(' UNIQUE', '')
+            self.deferred_sql.append(
+                self._create_index_sql(model, [field], sql=self.sql_create_unique_null, suffix="_uniq"))
         # Check constraints can go on the column SQL here
         db_params = field.db_parameters(connection=self.connection)
         if db_params['check']:
@@ -525,6 +535,10 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             definition, extra_params = self.column_sql(model, field)
             if definition is None:
                 continue
+            if field.null and field.unique:
+                definition = definition.replace(' UNIQUE', '')
+                self.deferred_sql.append(self._create_index_sql(
+                    model, [field], sql=self.sql_create_unique_null, suffix="_uniq"))
             # Check constraints can go on the column SQL here
             db_params = field.db_parameters(connection=self.connection)
             if db_params['check']:


### PR DESCRIPTION
This is another attempt at a fix for supporting unique nullable constraints with this library.

Based on work in #43 and resolves issues we encountered with adding/deleting these constraints through Django migrations.