### PR TITLE
Always enable limit for combined queries

### DIFF
--- a/sql_server/pyodbc/compiler.py
+++ b/sql_server/pyodbc/compiler.py
@@ -241,6 +241,7 @@ class SQLCompiler(compiler.SQLCompiler):
 
             # SQL Server requires the backend-specific emulation (2008 or earlier)
             # or an offset clause (2012 or newer) for offsetting
+            # Additionally support "limit" for queries that use UNION, EXCEPT
             if do_offset or (combinator and high_mark):
                 if do_offset_emulation:
                     # Construct the final SQL clause, using the initial select SQL

--- a/sql_server/pyodbc/compiler.py
+++ b/sql_server/pyodbc/compiler.py
@@ -241,7 +241,7 @@ class SQLCompiler(compiler.SQLCompiler):
 
             # SQL Server requires the backend-specific emulation (2008 or earlier)
             # or an offset clause (2012 or newer) for offsetting
-            if do_offset:
+            if do_offset or (combinator and high_mark):
                 if do_offset_emulation:
                     # Construct the final SQL clause, using the initial select SQL
                     # obtained above.


### PR DESCRIPTION
```
# Let's say queryset consists of unions
qs = qs.union(...)
qs = qs.union(...)

# Let's say queryset returns 20 objects total
assert qs.count() == 20

# Works fine if offset is higher than zero because "OFFSET 1 ROWS FETCH FIRST 10 ROWS ONLY" is applied
assert len(list(qs[1:10])) == 10

# This fails without my fix because "OFFSET 0 ROWS FETCH FIRST 10 ROWS ONLY" is not applied
assert len(list(qs[0:10])) == 10
```
