### PR TITLE
Add failover host

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -199,12 +199,23 @@ Dictionary. Current available keys are:
 
 -  connection_retry_backoff_time
 
-   Integer. Sets the back off time in seconds for reries of
+   Integer. Sets the back off time in seconds for retries of
    the database connection process. Default value is ``5``.
 
 -  query_timeout
 
    Integer. Sets the timeout in seconds for the database query.
+   Default value is ``0`` which disables the timeout.
+
+-  failover_partner
+
+   String. Same as HOST but for failover partner.
+   Default is not specified which disable the failover partner.
+
+-  connection_retry_failover_backoff_time
+
+   Integer.  Sets the back off time in seconds before trying
+   to connect to failover partner.
    Default value is ``0`` which disables the timeout.
 
 backend-specific settings

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ CLASSIFIERS=[
 
 setup(
     name='django-pyodbc-azure',
-    version='1.11.13.1',
+    version='1.11.13.1.post1',
     description='Django backend for Microsoft SQL Server and Azure SQL Database using pyodbc',
     long_description=open('README.rst').read(),
     author='Michiya Takahashi',

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ CLASSIFIERS=[
 
 setup(
     name='django-pyodbc-azure',
-    version='1.11.13.1.post2',
+    version='1.11.13.1',
     description='Django backend for Microsoft SQL Server and Azure SQL Database using pyodbc',
     long_description=open('README.rst').read(),
     author='Michiya Takahashi',

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ CLASSIFIERS=[
 
 setup(
     name='django-pyodbc-azure',
-    version='1.11.13.1.post1',
+    version='1.11.13.1.post2',
     description='Django backend for Microsoft SQL Server and Azure SQL Database using pyodbc',
     long_description=open('README.rst').read(),
     author='Michiya Takahashi',

--- a/sql_server/pyodbc/base.py
+++ b/sql_server/pyodbc/base.py
@@ -236,7 +236,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             conn_params['NAME'] = 'master'
         return conn_params
 
-    def get_new_connection(self, conn_params):
+    def _get_connection_strings(self, conn_params, options):
         database = conn_params['NAME']
         host = conn_params.get('HOST', 'localhost')
         user = conn_params.get('USER', None)
@@ -244,7 +244,6 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         port = conn_params.get('PORT', None)
 
         default_driver = 'SQL Server' if os.name == 'nt' else 'FreeTDS'
-        options = conn_params.get('OPTIONS', {})
         driver = options.get('driver', default_driver)
         dsn = options.get('dsn', None)
 
@@ -308,6 +307,13 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         failover_connstr = None
         if failover_host:
             failover_connstr = connstr.replace(host, failover_host, count=1)
+
+        return connstr, failover_connstr
+
+    def get_new_connection(self, conn_params):
+        options = conn_params.get('OPTIONS', {})
+
+        connstr, failover_connstr = self._get_connection_strings(conn_params, options)
 
         unicode_results = options.get('unicode_results', False)
         timeout = options.get('connection_timeout', 0)

--- a/sql_server/pyodbc/base.py
+++ b/sql_server/pyodbc/base.py
@@ -306,7 +306,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         failover_host = options.get('failover_partner', None)
         failover_connstr = None
         if failover_host:
-            failover_connstr = connstr.replace(host, failover_host, count=1)
+            failover_connstr = connstr.replace(host, failover_host, 1)
 
         return connstr, failover_connstr
 

--- a/sql_server/pyodbc/base.py
+++ b/sql_server/pyodbc/base.py
@@ -170,6 +170,12 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         '49919',
         '49920',
     )
+    _unrecoverable_error_numbers = (
+        '18486',  # account is locked
+        '18487',  # password expired
+        '18488',  # password should be changed
+        '18452',  # login from untrusted domain
+    )
 
     def __init__(self, *args, **kwargs):
         super(DatabaseWrapper, self).__init__(*args, **kwargs)
@@ -298,24 +304,49 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         if options.get('extra_params', None):
             connstr += ';' + options['extra_params']
 
+        failover_host = options.get('failover_partner', None)
+        failover_connstr = None
+        if failover_host:
+            failover_connstr = connstr.replace(host, failover_host, count=1)
+
         unicode_results = options.get('unicode_results', False)
         timeout = options.get('connection_timeout', 0)
         retries = options.get('connection_retries', 5)
         backoff_time = options.get('connection_retry_backoff_time', 5)
+        failover_backoff_time = options.get('connection_retry_failover_backoff_time', 0)
         query_timeout = options.get('query_timeout', 0)
 
         conn = None
         retry_count = 0
         need_to_retry = False
+        failover = False
+        error_numbers, failover_error_numbers = '', ''
         while conn is None:
             try:
                 conn = Database.connect(connstr,
                                         unicode_results=unicode_results,
                                         timeout=timeout)
             except Exception as e:
+                current_error_numbers = e.args[1]
+                for error_number in self._unrecoverable_error_numbers:  # never retry upon receiving unrecoverable code
+                    if error_number in current_error_numbers:
+                        raise
+
+                if not failover:
+                    error_numbers = current_error_numbers
+                else:
+                    failover_error_numbers = current_error_numbers
+
+                if failover_connstr:  # retry with failover if available
+                    connstr, failover_connstr = failover_connstr, connstr
+                    failover = not failover
+                    if failover:
+                        time.sleep(failover_backoff_time)
+                        continue
+
                 for error_number in self._transient_error_numbers:
-                    if error_number in e.args[1]:
-                        if error_number in e.args[1] and retry_count < retries:
+                    if error_number in error_numbers or error_number in failover_error_numbers:
+                        if retry_count < retries:
                             time.sleep(backoff_time)
                             need_to_retry = True
                             retry_count = retry_count + 1


### PR DESCRIPTION
Hello!
In our production setup we are using two MS SQL servers - one main and one failover.
Here is an implementation of the ability to specify such failover host (aka failover partner) which would be used during connection initiation if main server is currently down or unavailable.
