### PR TITLE
Implement altering Autofield

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -234,9 +234,12 @@ Here is an example of the database settings:
 Limitations
 -----------
 
-The following features are currently not supported:
+The following features are supported, working around SQL Server limitations:
 
-- Altering a model field from or to AutoField at migration
+- A NULL UNIQUE field (e.g. a `OneToOneField`) now properly allows multiple NULLs
+  (by replacing the "NULL UNIQUE" constraint with a "NULL" constraint and a "UNIQUE INDEX ... WITH <field> IS NOT NULL").
+- Because IDENTITY columns can't be altered, altering a model field from or to AutoField at migration
+  creates a new table so might be slow if the old table has many rows.
 
 Notice
 ------

--- a/sql_server/pyodbc/features.py
+++ b/sql_server/pyodbc/features.py
@@ -19,7 +19,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     requires_literal_defaults = True
     requires_sqlparse_for_splitting = False
     supports_index_on_text_field = False
-    supports_nullable_unique_constraints = False
+    supports_nullable_unique_constraints = True
     supports_paramstyle_pyformat = False
     supports_partially_nullable_unique_constraints = False
     supports_regex_backreferencing = False

--- a/sql_server/pyodbc/schema.py
+++ b/sql_server/pyodbc/schema.py
@@ -1,4 +1,6 @@
 import binascii
+import contextlib
+import copy
 import datetime
 
 from django.db.backends.base.schema import (
@@ -13,6 +15,7 @@ from django.db.models.fields.related import ManyToManyField
 from django.db.transaction import TransactionManagementError
 from django.utils.encoding import force_text
 
+from django.apps.registry import Apps
 
 class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
 
@@ -41,6 +44,21 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                                           "INNER JOIN sys.tables ro ON" \
                                           " fkc.referenced_object_id = ro.object_id " \
                                           "WHERE ro.name = %(table)s"
+    _sql_select_pk_uniq_key_constraints = "SELECT" \
+                                          " po.name AS table_name," \
+                                          " co.name AS constraint_name " \
+                                          "FROM sys.key_constraints ukc " \
+                                          "INNER JOIN sys.objects co ON" \
+                                          " ukc.object_id = co.object_id " \
+                                          "INNER JOIN sys.tables po ON" \
+                                          " ukc.parent_object_id = po.object_id " \
+                                          "INNER JOIN sys.tables ro ON" \
+                                          " ukc.parent_object_id = ro.object_id " \
+                                          "WHERE ro.name = %(table)s"
+    # the full set of constraints is in two different sys tables:
+    _sql_select_key_constraints = "{} UNION {}".format(
+        _sql_select_foreign_key_constraints,
+        _sql_select_pk_uniq_key_constraints)
     sql_alter_column_default = "ADD DEFAULT %(default)s FOR %(column)s"
     sql_alter_column_no_default = "DROP CONSTRAINT %(column)s"
     sql_alter_column_not_null = "ALTER COLUMN %(column)s %(type)s NOT NULL"
@@ -120,6 +138,159 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 [],
             )
 
+    # This is *copied* from django.db.backends.sqlite3.schema and then modified for SQL Server.
+    def _remake_table(self, model, create_field=None, delete_field=None, alter_field=None):
+        """
+        Shortcut to transform a model from old_model into new_model
+
+        The essential steps are:
+          1. rename the model's existing table, e.g. "app_model" to "app_model__old"
+          2. create a table with the updated definition called "app_model"
+          3. copy the data from the old renamed table to the new table
+          4. delete the "app_model__old" table
+        """
+        # Self-referential fields must be recreated rather than copied from
+        # the old model to ensure their remote_field.field_name doesn't refer
+        # to an altered field.
+        def is_self_referential(f):
+            return f.is_relation and f.remote_field.model is model
+        # Work out the new fields dict / mapping
+        body = {
+            f.name: f.clone() if is_self_referential(f) else f
+            for f in model._meta.local_concrete_fields
+        }
+        # Since mapping might mix column names and default values,
+        # its values must be already quoted.
+        mapping = {f.column: self.quote_name(f.column) for f in model._meta.local_concrete_fields}
+        # This maps field names (not columns) for things like unique_together
+        rename_mapping = {}
+        # If any of the new or altered fields is introducing a new PK,
+        # remove the old one
+        restore_pk_field = None
+        if getattr(create_field, 'primary_key', False) or (
+                alter_field and getattr(alter_field[1], 'primary_key', False)):
+            for name, field in list(body.items()):
+                if field.primary_key:
+                    field.primary_key = False
+                    restore_pk_field = field
+                    if field.auto_created:
+                        del body[name]
+                        del mapping[field.column]
+        # Add in any created fields
+        if create_field:
+            body[create_field.name] = create_field
+            # Choose a default and insert it into the copy map
+            if not create_field.many_to_many and create_field.concrete:
+                mapping[create_field.column] = self.quote_value(
+                    self.effective_default(create_field)
+                )
+        # Add in any altered fields
+        if alter_field:
+            old_field, new_field = alter_field
+            body.pop(old_field.name, None)
+            mapping.pop(old_field.column, None)
+            body[new_field.name] = new_field
+            if old_field.null and not new_field.null:
+                case_sql = "coalesce(%(col)s, %(default)s)" % {
+                    'col': self.quote_name(old_field.column),
+                    'default': self.quote_value(self.effective_default(new_field))
+                }
+                mapping[new_field.column] = case_sql
+            else:
+                mapping[new_field.column] = self.quote_name(old_field.column)
+            rename_mapping[old_field.name] = new_field.name
+        # Remove any deleted fields
+        if delete_field:
+            del body[delete_field.name]
+            del mapping[delete_field.column]
+            # Remove any implicit M2M tables
+            if delete_field.many_to_many and delete_field.remote_field.through._meta.auto_created:
+                return self.delete_model(delete_field.remote_field.through)
+        # Work inside a new app registry
+        apps = Apps()
+
+        # Provide isolated instances of the fields to the new model body so
+        # that the existing model's internals aren't interfered with when
+        # the dummy model is constructed.
+        body = copy.deepcopy(body)
+
+        # Work out the new value of unique_together, taking renames into
+        # account
+        unique_together = [
+            [rename_mapping.get(n, n) for n in unique]
+            for unique in model._meta.unique_together
+        ]
+
+        # Work out the new value for index_together, taking renames into
+        # account
+        index_together = [
+            [rename_mapping.get(n, n) for n in index]
+            for index in model._meta.index_together
+        ]
+
+        indexes = model._meta.indexes
+        if delete_field:
+            indexes = [
+                index for index in indexes
+                if delete_field.name not in index.fields
+            ]
+
+        # Construct a new model for the new state
+        meta_contents = {
+            'app_label': model._meta.app_label,
+            'db_table': model._meta.db_table,
+            'unique_together': unique_together,
+            'index_together': index_together,
+            'indexes': indexes,
+            'apps': apps,
+        }
+        meta = type("Meta", (), meta_contents)
+        body['Meta'] = meta
+        body['__module__'] = model.__module__
+
+        temp_model = type(model._meta.object_name, model.__bases__, body)
+
+        # We need to modify model._meta.db_table, but everything explodes
+        # if the change isn't reversed before the end of this method. This
+        # context manager helps us avoid that situation.
+        @contextlib.contextmanager
+        def altered_table_name(model, temporary_table_name):
+            original_table_name = model._meta.db_table
+            model._meta.db_table = temporary_table_name
+            yield
+            model._meta.db_table = original_table_name
+
+        with altered_table_name(model, model._meta.db_table + "__old"):
+            # Rename the old table to make way for the new
+            self.alter_db_table(
+                model, temp_model._meta.db_table, model._meta.db_table,
+                # disable_constraints=False,
+            )
+            # Create a new table with the updated schema.
+            self.create_model(temp_model)
+
+            # Copy data from the old table into the new table
+            field_maps = list(mapping.items())
+            self.execute("SET IDENTITY_INSERT %s ON" % self.quote_name(temp_model._meta.db_table))
+            self.execute("INSERT INTO %s (%s) SELECT %s FROM %s" % (
+                self.quote_name(temp_model._meta.db_table),
+                ', '.join(self.quote_name(x) for x, y in field_maps),
+                ', '.join(y for x, y in field_maps),
+                self.quote_name(model._meta.db_table),
+            ))
+            self.execute("SET IDENTITY_INSERT %s OFF" % self.quote_name(temp_model._meta.db_table))
+
+            # Delete the old table
+            self.delete_model(model)
+
+        # Run deferred SQL on correct table
+        for sql in self.deferred_sql:
+            self.execute(sql)
+        self.deferred_sql = []
+        # Fix any PK-removed field
+        if restore_pk_field:
+            restore_pk_field.primary_key = True
+
     def _alter_column_type_sql(self, model, old_field, new_field, new_type):
         new_type = self._set_field_new_type_null_status(old_field, new_type)
         return super()._alter_column_type_sql(model, old_field, new_field, new_type)
@@ -128,11 +299,6 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                      old_db_params, new_db_params, strict=False):
         """Actually perform a "physical" (non-ManyToMany) field update."""
 
-        # the backend doesn't support altering from/to (Big)AutoField
-        # because of the limited capability of SQL Server to edit IDENTITY property
-        for t in (AutoField, BigAutoField):
-            if isinstance(old_field, t) or isinstance(new_field, t):
-                raise NotImplementedError("the backend doesn't support altering from/to %s." % t.__name__)
         # Drop any FK constraints, we'll remake them later
         fks_dropped = set()
         if old_field.remote_field and old_field.db_constraint:
@@ -236,9 +402,12 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         post_actions = []
         # Type change?
         if old_type != new_type:
-            fragment, other_actions = self._alter_column_type_sql(model, old_field, new_field, new_type)
-            actions.append(fragment)
-            post_actions.extend(other_actions)
+            if isinstance(old_field, (AutoField, BigAutoField)) or isinstance(new_field, (AutoField, BigAutoField)):
+                self._remake_table(model, alter_field=(old_field, new_field))
+            else:
+                fragment, other_actions = self._alter_column_type_sql(model, old_field, new_field, new_type)
+                actions.append(fragment)
+                post_actions.extend(other_actions)
             # Drop unique constraint, SQL Server requires explicit deletion
             self._delete_unique_constraints(model, old_field, new_field, strict)
             # Drop indexes, SQL Server requires explicit deletion
@@ -393,6 +562,10 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             fragment, other_actions = self._alter_column_type_sql(
                 new_rel.related_model, old_rel.field, new_rel.field, rel_type
             )
+            # need to drop unique constraints, indexes, etc.
+            # TODO: take a look at remove_field() which deletes some other stuff as well.
+            self._delete_unique_constraints(old_rel.related_model, old_rel.field, new_rel.field, strict=False)
+            self._delete_indexes(old_rel.related_model, old_rel.field, new_rel.field)
             self.execute(
                 self.sql_alter_column % {
                     "table": self.quote_name(new_rel.related_model._meta.db_table),
@@ -625,9 +798,9 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         """
         Deletes a model from the database.
         """
-        # Delete the foreign key constraints
+        # Delete the foreign, primary and unique key constraints
         result = self.execute(
-            self._sql_select_foreign_key_constraints % {
+            self._sql_select_key_constraints % {
                 "table": self.quote_value(model._meta.db_table),
             },
             has_result = True

--- a/sql_server/pyodbc/schema.py
+++ b/sql_server/pyodbc/schema.py
@@ -52,6 +52,8 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
     sql_delete_table = "DROP TABLE %(table)s"
     sql_rename_column = "EXEC sp_rename '%(table)s.%(old_column)s', %(new_column)s, 'COLUMN'"
     sql_rename_table = "EXEC sp_rename %(old_table)s, %(new_table)s"
+    sql_create_unique_null = "CREATE UNIQUE INDEX %(name)s ON %(table)s(%(columns)s) " \
+                             "WHERE %(columns)s IS NOT NULL"
 
     def _alter_column_default_sql(self, model, old_field, new_field, drop=False):
         """
@@ -320,8 +322,15 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             self._delete_primary_key(model, strict)
         # Added a unique?
         if self._unique_should_be_added(old_field, new_field):
-            self.execute(self._create_unique_sql(model, [new_field.column]))
-        # Added an index?
+            if not new_field.many_to_many and new_field.null:
+                self.execute(
+                    self._create_index_sql(
+                        model, [new_field], sql=self.sql_create_unique_null, suffix="_uniq"
+                    )
+                )
+            else:
+                self.execute(self._create_unique_sql(model, [new_field.column]))
+         # Added an index?
         # constraint will no longer be used in lieu of an index. The following
         # lines from the truth table show all True cases; the rest are False:
         #
@@ -496,6 +505,13 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         # It might not actually have a column behind it
         if definition is None:
             return
+
+        if not field.many_to_many and field.null and field.unique:
+            definition = definition.replace(' UNIQUE', '')
+            self.deferred_sql.append(self._create_index_sql(
+                model, [field], sql=self.sql_create_unique_null, suffix="_uniq"
+            ))
+
         # Check constraints can go on the column SQL here
         db_params = field.db_parameters(connection=self.connection)
         if db_params['check']:
@@ -538,6 +554,13 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             definition, extra_params = self.column_sql(model, field)
             if definition is None:
                 continue
+
+            if not field.many_to_many and field.null and field.unique:
+                definition = definition.replace(' UNIQUE', '')
+                self.deferred_sql.append(self._create_index_sql(
+                    model, [field], sql=self.sql_create_unique_null, suffix="_uniq"
+                ))
+
             # Check constraints can go on the column SQL here
             db_params = field.db_parameters(connection=self.connection)
             if db_params['check']:


### PR DESCRIPTION
This removes the restriction on altering AutoFields. It is based off of PR #188.

Some additional testing is probably warranted, specifically to make sure all dropped constraints and indexes are added back after `_remake_table()`.

@michiya I'd appreciate your taking a look at this. 

It enables using SQL Server with [django-oauth-toolkit](https://github.com/jazzband/django-oauth-toolkit/issues/583), among others.