### PR TITLE
Problems with table names containing character '%', related issue #87

### DIFF
--- a/sql_server/pyodbc/base.py
+++ b/sql_server/pyodbc/base.py
@@ -495,9 +495,13 @@ class CursorWrapper(object):
             sql = smart_str(sql, self.driver_charset)
 
         # pyodbc uses '?' instead of '%s' as parameter placeholder.
+        # SQL identifiers (consequently table names) can contain special characters if surrounded by brackets '[...]'
+        # Replace only those placeholders:'%, %% %s etc.' which are not surrounded by brackets.            
+        # This is not complete solution, there may be problems with string literals in SQL etc.            
         if params is not None:
-            sql = sql % tuple('?' * len(params))
-
+            pattern = '''(?<![\[\]])\%[sbcdoxXn%]?(?![^\[\]]*\])'''
+            sql = re.sub(pattern,'?',sql)
+            
         return sql
 
     def format_params(self, params):


### PR DESCRIPTION
pyodbc uses '?' instead of '%s' as parameter placeholder.
SQL identifiers (consequently table names, columns) can contain special characters if surrounded by brackets '[...]'
Replace only those placeholders:'%, %%, %s, %d etc.' which are not surrounded by brackets.            
This is not complete solution, there may be problems with string literals in SQL etc. , if non string placeholder is found (example:%d) there should be error raised.

**Test:**
input:
`''', test,%ss,  [Company$Item].[Percentile %], [Company$Item],%s, [bfbfdb%vbddfb], %, %% [[%]], [%'''`
result:
`''', test,?s,  [Company$Item].[Percentile %], [Company$Item],?, [bfbfdb%vbddfb], ?, ? [[%]], [%'''`