### PR TITLE
Switch column introspection to use sp_columns instead of cursor.columns

### DIFF
--- a/sql_server/pyodbc/introspection.py
+++ b/sql_server/pyodbc/introspection.py
@@ -93,8 +93,12 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         of SQL_BIGAUTOFIELD, which maps to the 'BigAutoField' value in the DATA_TYPES_REVERSE dict.
         """
 
-        # map pyodbc's cursor.columns to db-api cursor description
-        columns = [[c[3], c[4], None, c[6], c[6], c[8], c[10], c[12]] for c in cursor.columns(table=table_name)]
+        # map T-SQL's `sp_columns` stored procedure to db-api cursor description
+        # https://docs.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-columns-transact-sql
+        columns = [
+            [c[3], c[4], None, c[6], c[6], c[8], c[10], c[12]]
+            for c in cursor.execute('exec sp_columns %s', [table_name]).fetchall()
+        ]
         items = []
         for column in columns:
             if identity_check and self._is_auto_field(cursor, table_name, column[0]):


### PR DESCRIPTION
I found `cursor.columns` to be less than reliable in returning _any_ results. The `sp_columns` returns the exact same data, and in local testing, was reliable 100% of the time for ~520 tables.