### PR TITLE
Let 1.11 version work with MSSQL 2019 / v15

### DIFF
--- a/sql_server/pyodbc/base.py
+++ b/sql_server/pyodbc/base.py
@@ -156,6 +156,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         12: 2014,
         13: 2016,
         14: 2017,
+        15: 2019,
     }
 
     # https://azure.microsoft.com/en-us/documentation/articles/sql-database-develop-csharp-retry-windows/


### PR DESCRIPTION
solves the error
```
  File "/usr/lib/python2.7/site-packages/sql_server/pyodbc/base.py", line 401, in sql_server_version
    raise NotImplementedError('SQL Server v%d is not supported.' % ver)
NotImplementedError: SQL Server v15 is not supported.
```
