### PR TITLE
Add compatibility for SQL Server 2019 v15

### DIFF
--- a/sql_server/pyodbc/base.py
+++ b/sql_server/pyodbc/base.py
@@ -157,6 +157,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         12: 2014,
         13: 2016,
         14: 2017,
+        15: 2017,
     }
 
     # https://azure.microsoft.com/en-us/documentation/articles/sql-database-develop-csharp-retry-windows/


### PR DESCRIPTION
The code works fine as is with v15, however connection fails as the key is missing from _sql_server_versions. Adding the key resolves this issue.